### PR TITLE
`JSON.stringify` success, RE: #7

### DIFF
--- a/src/functions/orderCreate.js
+++ b/src/functions/orderCreate.js
@@ -1,5 +1,22 @@
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY)
 
+/** Respond with status code 500 and error message */
+function errorResponse(err, callback) {
+  const response = {
+    headers: {
+      'Access-Control-Allow-Origin': '*'
+    },
+    statusCode: 500,
+    body: JSON.stringify({
+      error: err
+    })
+  }
+
+  if (typeof callback === 'function') {
+    callback(null, response)
+  }
+}
+
 /**
  * Captures payment token and creates order.
  */
@@ -8,47 +25,34 @@ module.exports.handler = async (event, context, callback) => {
   const { id, email } = requestBody.token
   const { currency, items, shipping } = requestBody.order
 
-  console.log(items)
-
   // Create order
-  const order = await stripe.orders
-    .create({
+  try {
+    const order = await stripe.orders.create({
       currency,
       items,
       shipping,
-      email
-    })
+      email,
+    });
+
     // Charge order
-    .then(order => {
-      stripe.orders.pay(order.id, {
-        source: id
-      })
+    stripe.orders.pay(order.id, {
+      source: id,
     })
-    .catch(err => errorResponse(err))
 
-  const response = {
-    headers: {
-      'Access-Control-Allow-Origin': '*'
-    },
-    statusCode: 200,
-    body: {
-      data: order,
-      message: 'Order placed successfully!'
-    }
-  }
-  callback(null, response)
-
-  /** Respond with status code 500 and error message */
-  function errorResponse(err) {
     const response = {
       headers: {
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': '*',
       },
-      statusCode: 500,
+      statusCode: 200,
       body: JSON.stringify({
-        error: err
-      })
+        data: order,
+        message: 'Order placed successfully!',
+      }),
     }
+
     callback(null, response)
+
+  } catch (e) {
+    errorResponse(e, callback)
   }
 }


### PR DESCRIPTION
* `Stringify` response body for success condition
* refactor `async / await` by adding `try / catch` block (vs `then.catch`)
* move error handler outside of closure & refactor it's method signature to accept a callback