### PR TITLE
dropdown prices don't reflect sorted 'prices' variable

### DIFF
--- a/src/components/ProductPage.js
+++ b/src/components/ProductPage.js
@@ -57,7 +57,7 @@ const ProductPage = ({ productId }) => {
           <label>
             Item Style
             <select name="price" id="price" onChange={onPriceChange}>
-              {product.prices.map((price, i) => {
+              {prices.map((price, i) => {
                 return (
                   <option value={i} key={price.id}>
                     {price.nickname} &ndash; ${price.unit_amount / 100}


### PR DESCRIPTION
Several items in my shop have multiple prices, which end up in the dropdown on the ProductPage, each mapped to an option tag. However, I noticed that the correct prices weren't mapped to the correct dropdown options (causing the wrong items to go into the cart). After looking into the matter, I noticed  that the products get sorted and stored in a 'prices' constant, which should also be reflected in the dropdown options. Otherwise, the unsorted prices end up there and you have mismatched prices and the wrong items end up in the cart. 

This is my first time attempting to explain an issue like this and my first contribution to a project on GitHub. Forgive me if my explanation was inadequate. I'm definitely a beginner! I love this starter, by the way.